### PR TITLE
Fix port number in the curl requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ Convert between OpenAPI v2 and v3 formats, it even converts YAML v2 to JSON v3 a
 
 ### Convert Swagger File to Open API v3, JSON Output
 
-`curl -s -X POST -d@swagger2.json "http://localhost:8082/v2tov3"`
+`curl -s -X POST -d@swagger2.json "http://localhost:8080/v2tov3"`
 
-`curl -s -X POST -d@swagger2.yaml "http://localhost:8082/v2tov3"`
+`curl -s -X POST -d@swagger2.yaml "http://localhost:8080/v2tov3"`
 
 ### Convert Swagger File to Open API v3, YAML Output
 
-`curl -s -X POST -d@swagger2.json "http://localhost:8082/v2tov3?format=yaml"`
+`curl -s -X POST -d@swagger2.json "http://localhost:8080/v2tov3?format=yaml"`
 
-`curl -s -X POST -d@swagger2.json "http://localhost:8082/v2tov3?format=yaml"`
+`curl -s -X POST -d@swagger2.json "http://localhost:8080/v2tov3?format=yaml"`
 
 ### Convert Open API v3 to File to Swagger (v2), JSON Output
 
-`curl -s -X POST -d@oas3.json "http://localhost:8082/v3tov2"`
+`curl -s -X POST -d@oas3.json "http://localhost:8080/v3tov2"`
 
-`curl -s -X POST -d@oas3.yaml "http://localhost:8082/v3tov2"`
+`curl -s -X POST -d@oas3.yaml "http://localhost:8080/v3tov2"`
 
 ### Convert Open API v3 to File to Swagger (v2), YAML Output
 
-`curl -s -X POST -d@oas3.json "http://localhost:8082/v3tov2?format=yaml"`
+`curl -s -X POST -d@oas3.json "http://localhost:8080/v3tov2?format=yaml"`
 
-`curl -s -X POST -d@oas3.yaml "http://localhost:8082/v3tov2?format=yaml"`
+`curl -s -X POST -d@oas3.yaml "http://localhost:8080/v3tov2?format=yaml"`
 
 ## Or do all that with Postman
 


### PR DESCRIPTION
The `docker run` command in the example exposes port 8080 while the sample curl requests are pointing to 8082.